### PR TITLE
Add auto-star feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ Different views of accessing Unread, Starred feed items.
    NOTION_API_TOKEN
    NOTION_READER_DATABASE_ID
    NOTION_FEEDS_DATABASE_ID
+   KEYWORDS  # optional comma separated list for auto-starred items
    ```
+
+   Items containing any of the provided keywords will be automatically marked as **Starred** in Notion.
 
    > To find your database id, visit your database on Notion. You'll get a URL like this: https://www.notion.so/{workspace_name}/{database_id}?v={view_id}. For example, if your URL looks like this: https://www.notion.so/abc/xyz?v=123, then `xyz` is your database ID.
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,16 +4,26 @@ import {
   deleteOldUnreadFeedItemsFromNotion,
 } from './notion';
 import htmlToNotionBlocks from './parser';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const KEYWORDS = process.env.KEYWORDS
+  ? process.env.KEYWORDS.split(',').map((k) => k.trim()).filter(Boolean)
+  : [];
 
 async function index() {
   const feedItems = await getNewFeedItems();
 
   for (let i = 0; i < feedItems.length; i++) {
     const item = feedItems[i];
+    const combinedText = `${item.title ?? ''} ${item.content ?? ''}`.toLowerCase();
+    const isStarred = KEYWORDS.some((kw) => combinedText.includes(kw.toLowerCase()));
     const notionItem = {
       title: item.title,
       link: item.link,
       content: htmlToNotionBlocks(item.content),
+      starred: isStarred,
     };
     await addFeedItemToNotion(notionItem);
   }

--- a/src/notion.js
+++ b/src/notion.js
@@ -47,7 +47,7 @@ export async function getFeedUrlsFromNotion() {
 }
 
 export async function addFeedItemToNotion(notionItem) {
-  const { title, link, content } = notionItem;
+  const { title, link, content, starred = false } = notionItem;
 
   const notion = new Client({
     auth: NOTION_API_TOKEN,
@@ -71,6 +71,9 @@ export async function addFeedItemToNotion(notionItem) {
         },
         Link: {
           url: link,
+        },
+        Starred: {
+          checkbox: starred,
         },
       },
       children: content,


### PR DESCRIPTION
## Summary
- star feed items automatically when they match KEYWORDS
- expose KEYWORDS in README

## Testing
- `node -c src/index.js`
- `node -c src/notion.js`