### PR TITLE
Add per-feed keyword filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Add, enable and disable your feed sources.
 
 ![](/screenshots/image-2.png)
 
+Filter individual feeds using comma separated keywords in the `Filter` column.
+
 Feeds are sourced daily and stored in the **Reader** database. New feed items are marked with 🔥.
 
 ![](/screenshots/image-3.png)

--- a/src/feed.js
+++ b/src/feed.js
@@ -7,7 +7,7 @@ dotenv.config();
 
 const { RUN_FREQUENCY } = process.env;
 
-async function getNewFeedItemsFrom(feedUrl) {
+async function getNewFeedItemsFrom(feedUrl, filterString = '') {
   const parser = new Parser();
   let rss;
   try {
@@ -19,11 +19,27 @@ async function getNewFeedItemsFrom(feedUrl) {
   const currentTime = new Date().getTime() / 1000;
 
   // Filter out items that fall in the run frequency range
-  return rss.items.filter((item) => {
+  let items = rss.items.filter((item) => {
     const blogPublishedTime = new Date(item.pubDate).getTime() / 1000;
     const { diffInSeconds } = timeDifference(currentTime, blogPublishedTime);
     return diffInSeconds < RUN_FREQUENCY;
   });
+
+  const keywords = filterString
+    .split(',')
+    .map((kw) => kw.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (keywords.length === 0) {
+    return items;
+  }
+
+  items = items.filter((item) => {
+    const text = `${item.title ?? ''} ${item.content ?? ''}`.toLowerCase();
+    return keywords.some((kw) => text.includes(kw));
+  });
+
+  return items;
 }
 
 export default async function getNewFeedItems() {
@@ -32,8 +48,8 @@ export default async function getNewFeedItems() {
   const feeds = await getFeedUrlsFromNotion();
 
   for (let i = 0; i < feeds.length; i++) {
-    const { feedUrl } = feeds[i];
-    const feedItems = await getNewFeedItemsFrom(feedUrl);
+    const { feedUrl, filter } = feeds[i];
+    const feedItems = await getNewFeedItemsFrom(feedUrl, filter);
     allNewFeedItems = [...allNewFeedItems, ...feedItems];
   }
 

--- a/src/notion.js
+++ b/src/notion.js
@@ -38,10 +38,16 @@ export async function getFeedUrlsFromNotion() {
     return [];
   }
 
-  const feeds = response.results.map((item) => ({
-    title: item.properties.Title.title[0].plain_text,
-    feedUrl: item.properties.Link.url,
-  }));
+  const feeds = response.results.map((item) => {
+    const filter =
+      item.properties.Filter?.rich_text?.map((t) => t.plain_text).join('') || '';
+
+    return {
+      title: item.properties.Title.title[0].plain_text,
+      feedUrl: item.properties.Link.url,
+      filter,
+    };
+  });
 
   return feeds;
 }


### PR DESCRIPTION
## Summary
- parse `Filter` property from feeds database
- filter feed items per source using comma-separated keywords
- document `Filter` column in README

------
https://chatgpt.com/codex/tasks/task_e_6857697be7b0832182fef42bdc730093